### PR TITLE
@camilaesouza/62/fix/only-show-form-templates-with-questions

### DIFF
--- a/app/Http/Controllers/Api/SocialAssistant/SocialAssistantFormTemplateController.php
+++ b/app/Http/Controllers/Api/SocialAssistant/SocialAssistantFormTemplateController.php
@@ -81,6 +81,7 @@ class SocialAssistantFormTemplateController extends Controller
 
         try {
             $formTemplates = FormTemplate::query()
+                ->whereHas('shortQuestions')
                 ->whereHas('organizations', function ($query) use ($organization) {
                     return $query->where('organization_id', $organization->id);
                 })->get();

--- a/tests/Feature/Controllers/Api/SocialAssistant/SocialAssistantFormTemplateControllerTest.php
+++ b/tests/Feature/Controllers/Api/SocialAssistant/SocialAssistantFormTemplateControllerTest.php
@@ -6,6 +6,7 @@ use App\Enums\RolesEnum;
 use App\Models\FormTemplate;
 use App\Models\Organization;
 use App\Models\Role;
+use App\Models\ShortQuestion;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -41,6 +42,9 @@ class SocialAssistantFormTemplateControllerTest extends TestCase
     public function testGetToSelectMethod()
     {
         $formTemplates = FormTemplate::factory()->hasAttached($this->organization)->count(10)->createQuietly();
+        foreach ($formTemplates as $formTemplate) {
+         ShortQuestion::factory()->createOne(['form_template_id' => $formTemplate->id]);
+        }
 
         $response = $this->getJson(route('social-assistant.form-templates.get-to-select', $this->organization));
 


### PR DESCRIPTION
# Description

## Resume
- Fix to only shor form templates with question on to select method

## Related Issues
https://github.com/open-social-care/backend/issues/62

## Observation
- Fix front end developer 

## Checklist
- [x] I followed the project's code conventions.
- [x] I have added tests to cover the changes made.
- [x] I have updated the documentation, if necessary.
- [x] This PR has been tested locally and is ready for review.
